### PR TITLE
Support multi-template services and expose columnFormIPM row schema

### DIFF
--- a/lib/aws-client.js
+++ b/lib/aws-client.js
@@ -169,55 +169,104 @@ const INPUT_SUBTYPES = new Set([
   'columnFormIPM', 'dataTransferV2',
 ]);
 
+// Human-readable hint describing the value shape the calculator
+// frontend expects for a columnFormIPM composite widget. Exposed to
+// agents so they can supply an already-shaped value without guessing.
+const COLUMN_FORM_IPM_VALUE_SHAPE =
+  'columnFormIPM expects {value: [rowObject]} — an array of one or more row objects. ' +
+  'Each row is keyed by the selectorId (or label where no selectorId is defined; ' +
+  'the utilization row uses the literal key "undefined"). Every cell wraps its value as ' +
+  '{value: ...}. Example for RDS: {value: [{"Number of Nodes": {value: "1"}, ' +
+  '"Instance Type": {value: "db.r6g.xlarge"}, "undefined": {value: {unit: "100", ' +
+  'selectedId: "%Utilized/Month"}}, "Deployment Option": {value: "Single-AZ"}, ' +
+  '"TermType": {value: "OnDemand"}}]}.';
+
 function extractInputFields(definition) {
   const fields = [];
   const seen = new Set();
 
-  const walk = (obj) => {
+  const visit = (obj, templateId) => {
     if (!obj || typeof obj !== 'object') return;
     if (obj.id && (INPUT_TYPES.has(obj.type) || INPUT_SUBTYPES.has(obj.subType))) {
       const fieldType = obj.subType || obj.type;
       // Skip non-input decorative types
-      if (['bodyText', 'headerText', 'alert'].includes(fieldType)) return;
-      // Skip "without free tier" / MVP duplicate fields — these are alternate
-      // versions of the same inputs for different pricing modes
-      if (obj.id.includes('WithoutFreeTier') || obj.id.includes('_withoutFree') || obj.id.endsWith('_MVP')) return;
-      // Deduplicate (some definitions repeat fields across templates)
-      const dedupKey = obj.id + ':' + fieldType;
-      if (seen.has(dedupKey)) return;
-      seen.add(dedupKey);
+      if (['bodyText', 'headerText', 'alert'].includes(fieldType)) {
+        // still walk into children — decorative wrappers may host inputs
+      } else if (obj.id.includes('WithoutFreeTier') || obj.id.includes('_withoutFree') || obj.id.endsWith('_MVP')) {
+        // Skip "without free tier" / MVP duplicate fields — these are alternate
+        // versions of the same inputs for different pricing modes
+      } else {
+        // Deduplicate across templates by id+type. We still remember the
+        // *first* template we found the field in, so agents can tell
+        // which template a field belongs to when they are disjoint
+        // (e.g. Amazon MQ's ActiveMQ vs RabbitMQ templates).
+        const dedupKey = obj.id + ':' + fieldType;
+        if (!seen.has(dedupKey)) {
+          seen.add(dedupKey);
 
-      const field = { id: obj.id, type: fieldType };
-      if (obj.label) field.label = obj.label;
-      if (obj.options) {
-        field.options = obj.options
-          .filter(o => o.id !== undefined || o.label !== undefined)
-          .map(o => {
-            const opt = {};
-            if (o.id !== undefined) opt.id = o.id;
-            if (o.label) opt.label = o.label;
-            return opt;
-          });
+          const field = { id: obj.id, type: fieldType };
+          if (templateId) field.templateId = templateId;
+          if (obj.label) field.label = obj.label;
+          if (obj.options) {
+            field.options = obj.options
+              .filter(o => o.id !== undefined || o.label !== undefined)
+              .map(o => {
+                const opt = {};
+                if (o.id !== undefined) opt.id = o.id;
+                if (o.label) opt.label = o.label;
+                return opt;
+              });
+          }
+          if (obj.unit) field.unit = obj.unit;
+          // fileSize fields: include valid size units and default unit format
+          if (fieldType === 'fileSize') {
+            const sizes = obj.dropDownSize?.map(s => s.value || s.id) || ['gb'];
+            const defaultSize = obj.defaultOption?.size || 'gb';
+            const defaultFreq = obj.defaultOption?.frequency || 'NA';
+            field.unitFormat = `{value}|{size}|{frequency} — sizes: [${sizes.join(', ')}], default: "${defaultSize}|${defaultFreq}"`;
+            field.validSizes = sizes;
+            field.defaultUnit = `${defaultSize}|${defaultFreq}`;
+          }
+          // columnFormIPM composite: expose the row schema so an
+          // agent can build the expected value shape without trial
+          // and error. The calculator stores this as a matrix keyed
+          // by selectorId (or label when no selectorId), with a
+          // literal "undefined" key for the utilization row.
+          if (fieldType === 'columnFormIPM') {
+            field.row = (obj.row || []).map(r => {
+              const item = {
+                label: r.label,
+                selectorId: r.selectorId,
+                type: r.type,
+              };
+              if (r.exportValueAs) item.exportValueAs = r.exportValueAs;
+              if (r.isInstanceType) item.isInstanceType = true;
+              if (r.mappingValue) item.mappingValue = r.mappingValue;
+              return item;
+            });
+            field.valueShape = COLUMN_FORM_IPM_VALUE_SHAPE;
+          }
+          fields.push(field);
+        }
       }
-      if (obj.unit) field.unit = obj.unit;
-      // fileSize fields: include valid size units and default unit format
-      if (fieldType === 'fileSize') {
-        const sizes = obj.dropDownSize?.map(s => s.value || s.id) || ['gb'];
-        const defaultSize = obj.defaultOption?.size || 'gb';
-        const defaultFreq = obj.defaultOption?.frequency || 'NA';
-        field.unitFormat = `{value}|{size}|{frequency} — sizes: [${sizes.join(', ')}], default: "${defaultSize}|${defaultFreq}"`;
-        field.validSizes = sizes;
-        field.defaultUnit = `${defaultSize}|${defaultFreq}`;
-      }
-      fields.push(field);
     }
     for (const v of Object.values(obj)) {
-      if (Array.isArray(v)) v.forEach(walk);
-      else if (typeof v === 'object') walk(v);
+      if (Array.isArray(v)) v.forEach(x => visit(x, templateId));
+      else if (typeof v === 'object') visit(v, templateId);
     }
   };
 
-  walk(definition.templates || definition);
+  // Walk each template separately so fields can be tagged with their
+  // owning template. This lets callers (agents, the estimate builder)
+  // tell which template a given field belongs to when a service has
+  // more than one (e.g. Amazon MQ → singleInstanceBroker vs
+  // rabbitMQBroker).
+  const templates = Array.isArray(definition.templates) ? definition.templates : null;
+  if (templates && templates.length > 0) {
+    for (const tpl of templates) visit(tpl, tpl.id);
+  } else {
+    visit(definition, null);
+  }
   return fields;
 }
 

--- a/lib/estimate-builder.js
+++ b/lib/estimate-builder.js
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 const crypto = require('crypto');
-const { PARTITIONS, resolvePartition, loadManifest, findService, fetchServiceDefinition, saveEstimate } = require('./aws-client');
+const { PARTITIONS, resolvePartition, loadManifest, findService, fetchServiceDefinition, saveEstimate, extractInputFields } = require('./aws-client');
 const ec2 = require('./ec2');
 
 const REGIONS = {
@@ -193,6 +193,51 @@ class EstimateBuilder {
     return this._isEC2(service) ? 'ec2Enhancement' : service.key;
   }
 
+  // Pick the template whose field IDs best match the config the agent
+  // supplied. This solves the multi-template case (e.g. Amazon MQ has
+  // both singleInstanceBroker and rabbitMQBroker and the right one
+  // depends entirely on which field IDs are in use). When nothing
+  // disambiguates, fall back to templates[0] for back-compat.
+  _inferTemplateId(def, config) {
+    const templates = def.templates;
+    if (!Array.isArray(templates) || templates.length === 0) return 'template';
+    if (templates.length === 1) return templates[0].id;
+
+    const configFieldIds = Object.keys(config)
+      .filter(k => k !== 'region' && k !== 'description');
+    if (configFieldIds.length === 0) return templates[0].id;
+
+    // Count how many of the config's field IDs each template declares.
+    const fields = extractInputFields(def);
+    const fieldToTemplate = new Map();
+    for (const f of fields) {
+      if (f.templateId) fieldToTemplate.set(f.id, f.templateId);
+    }
+
+    const scores = new Map();
+    for (const id of configFieldIds) {
+      const tpl = fieldToTemplate.get(id);
+      if (tpl) scores.set(tpl, (scores.get(tpl) || 0) + 1);
+    }
+
+    if (scores.size === 0) return templates[0].id;
+
+    // Pick the template with the highest score; break ties in favour
+    // of the template that appears first in the definition so the
+    // behaviour remains deterministic and back-compat for ambiguous
+    // configs.
+    let best = templates[0].id;
+    let bestScore = -1;
+    for (const tpl of templates) {
+      const s = scores.get(tpl.id) || 0;
+      if (s > bestScore) {
+        bestScore = s;
+        best = tpl.id;
+      }
+    }
+    return best;
+  }
+
   async _buildServiceConfig(manifest, service, config, partition) {
     const region = config.region || 'us-east-1';
     const defKey = this._payloadKey(service);
@@ -203,7 +248,7 @@ class EstimateBuilder {
       if (def) {
         version = def.version || version;
         serviceCode = def.serviceCode || serviceCode;
-        estimateFor = def.templates?.[0]?.id || estimateFor;
+        estimateFor = this._inferTemplateId(def, config);
       }
     } catch (err) {
       console.error(`Failed to fetch definition for ${defKey}: ${err.message}`);

--- a/test/templates.test.js
+++ b/test/templates.test.js
@@ -1,0 +1,296 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+//
+// Tests for multi-template services (e.g. Amazon MQ with ActiveMQ +
+// RabbitMQ) and for the columnFormIPM composite row widget used by
+// Amazon RDS engines.
+//
+// Design intent: the MCP surfaces the raw shape of the service
+// definition (per-template fields, IPM row schema) so an agent can
+// make informed choices; the MCP infers the template from the config
+// keys it received rather than blindly picking templates[0].
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { extractInputFields } = require('../lib/aws-client');
+
+// ─── helpers ────────────────────────────────────────────────
+
+function clearCaches() {
+  delete require.cache[require.resolve('../lib/aws-client')];
+  delete require.cache[require.resolve('../lib/estimate-builder')];
+}
+
+function mockFetch(responses) {
+  global.fetch = async (url) => {
+    for (const [pattern, body] of responses) {
+      if (url.includes(pattern)) {
+        return { ok: true, json: async () => body, text: async () => JSON.stringify(body) };
+      }
+    }
+    return { ok: false, status: 404, json: async () => ({}), text: async () => '404' };
+  };
+}
+
+// ─── fixtures ───────────────────────────────────────────────
+// Minimal MQ-shaped definition: two templates with distinct field IDs.
+const MQ_DEF = {
+  version: '0.0.59',
+  serviceCode: 'amazonMQ',
+  templates: [
+    {
+      id: 'singleInstanceBroker',
+      cards: [{ inputSection: { components: [
+        { id: 'activeBrokerType', type: 'input', subType: 'dropdown', label: 'Broker type' },
+        { id: 'numberOfBrokers', type: 'numericInput', label: 'Number of Brokers running' },
+        { id: 'instanceType', type: 'input', subType: 'dropdown', label: 'Amazon MQ Broker Instance',
+          options: [{ id: 'mq.m5.large-id', label: 'mq.m5.large' }] },
+        { id: 'storagePerBroker', type: 'fileSize', label: 'Storage per Broker',
+          dropDownSize: [{ value: 'gb' }], defaultOption: { size: 'gb', frequency: 'NA' } },
+      ]}}],
+    },
+    {
+      id: 'rabbitMQBroker',
+      cards: [{ inputSection: { components: [
+        { id: 'rabbitBrokerType', type: 'input', subType: 'dropdown', label: 'Broker type' },
+        { id: 'rabbitmqNumberOfBrokers', type: 'numericInput', label: 'Number of Brokers running' },
+        { id: 'rabbitmqInstanceType', type: 'input', subType: 'dropdown', label: 'Amazon RabbitMQ Broker Instance',
+          options: [{ id: 'mq.m5.large-rabbit-id', label: 'mq.m5.large' }] },
+        { id: 'rabbitmqStoragePerBroker', type: 'fileSize', label: 'Storage per Broker',
+          dropDownSize: [{ value: 'gb' }], defaultOption: { size: 'gb', frequency: 'NA' } },
+      ]}}],
+    },
+  ],
+};
+
+// Minimal RDS-shaped definition with a columnFormIPM composite.
+const RDS_DEF = {
+  version: '0.0.110',
+  serviceCode: 'amazonRDSPostgreSQLDB',
+  templates: [
+    {
+      id: 'rdsForPostgreSQL',
+      cards: [{ inputSection: { components: [
+        {
+          id: 'columnFormIPM',
+          type: 'input',
+          subType: 'columnFormIPM',
+          mappingDefinitionName: 'rds-postgresql-calc',
+          row: [
+            { label: 'Nodes', selectorId: 'Number of Nodes', type: 'textInput', exportValueAs: 'count' },
+            { label: 'Instance Type', selectorId: 'Instance Type', type: 'autoSuggest', isInstanceType: true },
+            { label: 'Utilization (On-Demand only)', type: 'utilization', exportValueAs: 'utilizationOut' },
+            { label: 'Deployment Option', selectorId: 'Deployment Option', type: 'dropDown', exportValueAs: 'deploymentStrategy' },
+            { label: 'Pricing Model', selectorId: 'TermType', type: 'dropDown', exportValueAs: 'pricingModel' },
+          ],
+        },
+        { id: 'storageVolume', type: 'input', subType: 'dropdown', label: 'Storage volume',
+          options: [{ id: 'General Purpose-GP3', label: 'General Purpose SSD (gp3)' }] },
+        { id: 'storageAmount', type: 'fileSize', label: 'Storage amount',
+          dropDownSize: [{ value: 'gb' }], defaultOption: { size: 'gb', frequency: 'NA' } },
+      ]}}],
+    },
+  ],
+};
+
+const FAKE_MANIFEST = {
+  awsServices: [
+    { key: 'amazonMQ', name: 'Amazon MQ', serviceCode: 'amazonMQ' },
+    { key: 'amazonRDSPostgreSQLDB', name: 'Amazon RDS for PostgreSQL', serviceCode: 'amazonRDSPostgreSQLDB' },
+  ],
+};
+
+// ════════════════════════════════════════════════════════════
+// extractInputFields — per-template grouping + IPM row schema
+// ════════════════════════════════════════════════════════════
+
+describe('extractInputFields — multi-template services', () => {
+  it('tags each field with the template it belongs to', () => {
+    const fields = extractInputFields(MQ_DEF);
+    const byId = Object.fromEntries(fields.map(f => [f.id, f]));
+    assert.equal(byId.activeBrokerType.templateId, 'singleInstanceBroker',
+      'ActiveMQ field should be tagged with its template');
+    assert.equal(byId.rabbitBrokerType.templateId, 'rabbitMQBroker',
+      'RabbitMQ field should be tagged with its template');
+  });
+
+  it('lists all fields across all templates (not just templates[0])', () => {
+    const fields = extractInputFields(MQ_DEF);
+    const ids = fields.map(f => f.id);
+    // Field IDs that only exist in template[1] must still be visible
+    assert.ok(ids.includes('rabbitmqInstanceType'),
+      'RabbitMQ field from templates[1] must be exposed');
+    assert.ok(ids.includes('instanceType'),
+      'ActiveMQ field from templates[0] must be exposed');
+  });
+});
+
+describe('extractInputFields — columnFormIPM row schema', () => {
+  it('exposes the row schema so an agent knows the expected keys', () => {
+    const fields = extractInputFields(RDS_DEF);
+    const ipm = fields.find(f => f.id === 'columnFormIPM');
+    assert.ok(ipm, 'columnFormIPM field should be extracted');
+    assert.equal(ipm.type, 'columnFormIPM');
+    assert.ok(Array.isArray(ipm.row), 'should include row schema');
+    assert.ok(ipm.row.length >= 5, 'should include all row items');
+  });
+
+  it('includes selectorId, label, type and exportValueAs per row', () => {
+    const fields = extractInputFields(RDS_DEF);
+    const ipm = fields.find(f => f.id === 'columnFormIPM');
+    const byLabel = Object.fromEntries(ipm.row.map(r => [r.label, r]));
+    assert.equal(byLabel['Instance Type'].selectorId, 'Instance Type');
+    assert.equal(byLabel['Instance Type'].type, 'autoSuggest');
+    assert.equal(byLabel['Nodes'].exportValueAs, 'count');
+    assert.equal(byLabel['Pricing Model'].selectorId, 'TermType');
+  });
+
+  it('documents the expected value shape for columnFormIPM', () => {
+    const fields = extractInputFields(RDS_DEF);
+    const ipm = fields.find(f => f.id === 'columnFormIPM');
+    // The agent needs an example of how to shape the value. We expose
+    // a hint string describing the array-of-rows-keyed-by-label shape.
+    assert.ok(ipm.valueShape, 'valueShape hint should be present');
+    assert.match(ipm.valueShape, /array/i, 'should mention array');
+    assert.match(ipm.valueShape, /selectorId/i, 'should mention selectorId usage');
+  });
+});
+
+// ════════════════════════════════════════════════════════════
+// template inference — pick the template whose fields match
+// ════════════════════════════════════════════════════════════
+
+describe('template inference in _buildServiceConfig', () => {
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    clearCaches();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    clearCaches();
+  });
+
+  it('picks rabbitMQBroker when config uses RabbitMQ-only field IDs', async () => {
+    mockFetch([
+      ['manifest/en_US.json', FAKE_MANIFEST],
+      ['data/amazonMQ', MQ_DEF],
+    ]);
+    const EB = require('../lib/estimate-builder');
+    const eb = new EB('MQ inference test');
+    eb.addService('amazonMQ', {
+      region: 'eu-south-1',
+      description: 'RabbitMQ 3x mq.m5.large',
+      rabbitBrokerType: '1',
+      rabbitmqNumberOfBrokers: '3',
+      rabbitmqInstanceType: 'mq.m5.large-rabbit-id',
+    });
+    const payload = await eb.toAWSPayload();
+    const svc = Object.values(payload.services)[0];
+    assert.equal(svc.estimateFor, 'rabbitMQBroker',
+      'estimateFor must reflect the template that actually contains the configured fields');
+  });
+
+  it('picks singleInstanceBroker when config uses ActiveMQ-only field IDs', async () => {
+    mockFetch([
+      ['manifest/en_US.json', FAKE_MANIFEST],
+      ['data/amazonMQ', MQ_DEF],
+    ]);
+    const EB = require('../lib/estimate-builder');
+    const eb = new EB('MQ ActiveMQ test');
+    eb.addService('amazonMQ', {
+      region: 'us-east-1',
+      description: 'ActiveMQ',
+      activeBrokerType: '1',
+      numberOfBrokers: '1',
+      instanceType: 'mq.m5.large-id',
+    });
+    const payload = await eb.toAWSPayload();
+    const svc = Object.values(payload.services)[0];
+    assert.equal(svc.estimateFor, 'singleInstanceBroker');
+  });
+
+  it('falls back to templates[0] when no config keys disambiguate', async () => {
+    mockFetch([
+      ['manifest/en_US.json', FAKE_MANIFEST],
+      ['data/amazonMQ', MQ_DEF],
+    ]);
+    const EB = require('../lib/estimate-builder');
+    const eb = new EB('MQ ambiguous test');
+    eb.addService('amazonMQ', { region: 'us-east-1', description: 'No fields' });
+    const payload = await eb.toAWSPayload();
+    const svc = Object.values(payload.services)[0];
+    assert.equal(svc.estimateFor, 'singleInstanceBroker',
+      'with no signal, keep back-compat behaviour and use templates[0]');
+  });
+
+  it('uses templates[0] for single-template services (RDS PostgreSQL)', async () => {
+    mockFetch([
+      ['manifest/en_US.json', FAKE_MANIFEST],
+      ['data/amazonRDSPostgreSQLDB', RDS_DEF],
+    ]);
+    const EB = require('../lib/estimate-builder');
+    const eb = new EB('RDS single template');
+    eb.addService('amazonRDSPostgreSQLDB', {
+      region: 'eu-south-1',
+      description: 'Primary',
+      storageVolume: 'General Purpose-GP3',
+      storageAmount: { value: '100', unit: 'gb|NA' },
+    });
+    const payload = await eb.toAWSPayload();
+    const svc = Object.values(payload.services)[0];
+    assert.equal(svc.estimateFor, 'rdsForPostgreSQL');
+  });
+});
+
+// ════════════════════════════════════════════════════════════
+// columnFormIPM passthrough — agent supplies the shape, MCP
+// must not mangle it.
+// ════════════════════════════════════════════════════════════
+
+describe('columnFormIPM passthrough', () => {
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    clearCaches();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    clearCaches();
+  });
+
+  it('passes an already-shaped columnFormIPM value through unchanged', async () => {
+    mockFetch([
+      ['manifest/en_US.json', FAKE_MANIFEST],
+      ['data/amazonRDSPostgreSQLDB', RDS_DEF],
+    ]);
+    const EB = require('../lib/estimate-builder');
+    const eb = new EB('RDS IPM test');
+
+    const ipmValue = {
+      value: [{
+        'Number of Nodes': { value: '1' },
+        'Instance Type': { value: 'db.r6g.4xlarge' },
+        'undefined': { value: { unit: '100', selectedId: '%Utilized/Month' } },
+        'Deployment Option': { value: 'Single-AZ' },
+        'TermType': { value: 'OnDemand' },
+      }],
+    };
+
+    eb.addService('amazonRDSPostgreSQLDB', {
+      region: 'eu-south-1',
+      description: 'Primary db.r6g.4xlarge',
+      columnFormIPM: ipmValue,
+      storageVolume: 'General Purpose-GP3',
+      storageAmount: { value: '3700', unit: 'gb|NA' },
+    });
+    const payload = await eb.toAWSPayload();
+    const svc = Object.values(payload.services)[0];
+    assert.deepEqual(svc.calculationComponents.columnFormIPM, ipmValue,
+      'columnFormIPM must reach the payload exactly as supplied');
+  });
+});


### PR DESCRIPTION
Before this change, two calculator service types could not be configured through the MCP:

1. Multi-template services (e.g. Amazon MQ with separate singleInstanceBroker and rabbitMQBroker templates) were always saved with estimateFor set to templates[0].id. Fields belonging to the non-default template were silently stored but ignored by the frontend, so the saved estimate always defaulted to ActiveMQ regardless of the config.

2. The columnFormIPM composite widget (used by every RDS engine to select instance type, deployment option and pricing model) was not exposed to agents via get_service_fields, so the expected value shape had to be reverse-engineered from a UI-built estimate.

This change surfaces the raw definition structure so callers can make informed choices:

* extractInputFields now walks each template independently and tags every field with its templateId, so multi-template services (Amazon MQ, RDS engines with Reserved variants, ...) are fully enumerated.

* columnFormIPM fields are extracted with their row schema (selectorId, label, type, exportValueAs) and a valueShape hint describing the array-of-rows-keyed-by-selectorId shape the frontend expects.

* EstimateBuilder._buildServiceConfig picks the template whose field IDs best match the config, instead of blindly using templates[0]. Ties and configs that match no template fall back to templates[0] for back-compat; single-template services are unchanged.

10 new tests in test/templates.test.js cover the per-template tagging, IPM row schema extraction, value-shape hint, template inference for RabbitMQ vs ActiveMQ, fallback behaviour, single-template services and columnFormIPM passthrough. All 70 tests pass.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
