### PR TITLE
Send unit fields in validation buildConfig

### DIFF
--- a/validation/run-validation.js
+++ b/validation/run-validation.js
@@ -95,23 +95,27 @@ function buildConfig(serviceName, serviceConfig, region) {
     const fieldId = fieldInfo.fieldId;
     if (!fieldId) continue;
 
-    // Use default value if available
+    let valueSet = false;
+
     if (fieldInfo.defaultValue) {
       config[fieldId] = fieldInfo.defaultValue;
-      continue;
-    }
-
-    // Use first allowed value for dropdowns
-    if (fieldInfo.allowedValues && fieldInfo.allowedValues.length > 0) {
+      valueSet = true;
+    } else if (fieldInfo.allowedValues && fieldInfo.allowedValues.length > 0) {
       config[fieldId] = fieldInfo.allowedValues[0];
+      valueSet = true;
+    } else if (fieldInfo.type === 'autosuggest') {
       continue;
+    } else {
+      config[fieldId] = '1';
+      valueSet = true;
     }
 
-    // Skip autosuggest fields (require specific valid values)
-    if (fieldInfo.type === 'autosuggest') continue;
-
-    // Provide a sensible default for numeric inputs
-    config[fieldId] = '1';
+    // Calculator stores units in a sister field (e.g. numberOfRequests_unit).
+    // Without it the API accepts the save, but rehydration silently re-defaults
+    // or drops the value. Send unit when the mapping declares unit_field.
+    if (valueSet && fieldInfo.unit_field) {
+      config[fieldInfo.unit_field] = fieldInfo.unit || fieldInfo.default_unit;
+    }
   }
 
   return config;


### PR DESCRIPTION
## Summary

- Fix: \`buildConfig\` in \`validation/run-validation.js\` now sends sister \`{fieldId}_unit\` entries declared by \`field-mapping.json\` (e.g. \`numberOfRequests_unit: perMonth\`).
- Without these, the calculator silently drops or re-defaults the value at rehydration even though the save API accepts the payload — a failure mode invisible to API-only smoke and to the current DOM-scrape visual validator, but visible in the CSV Configuration summary column.

## Why

Currently \`buildConfig\` writes only \`config[fieldId] = defaultValue || allowedValues[0] || '1'\`. The field-mapping declares unit metadata in two ways: the \`unit\` / \`default_unit\` properties on the mapping entry, and a sister field name in \`unit_field\`. The frontend pricing calculator stores both halves in \`calculationComponents\` and uses the unit field at rehydration.

Concrete impact (verified against a fresh Lambda save):

| | Bytes saved | CSV Configuration summary after rehydration |
|---|---:|---|
| pre-fix | 1032 | \`Invoke Mode (Buffered)\` (the four input fields silently dropped) |
| post-fix | 1379 | \`Number of requests (1 million per month), Duration of each request (100 ms), Amount of memory allocated (512 MB), Amount of ephemeral storage allocated (512 MB), Invoke Mode (Buffered)\` |

This is the same class of failure that produced the eC2Next "Read-only" empty estimates and the gp3 IOPS silent-default behaviour — value accepted at save, dropped at rehydrate.

## Test plan

- [x] \`npm test\` — 70/70 unit tests pass on this branch.
- [x] \`node validation/run-validation.js --service Lambda --verbose\` — Lambda passes API validation; saved estimate's payload is 1379 bytes (vs 1032 pre-fix).
- [x] Diffed estimates: \`https://calculator.aws/#/estimate?id=6981c8dfa1747fbe8a828ad57c01e65f56fe07a3\` (post-fix, all four input fields surface) vs \`https://calculator.aws/#/estimate?id=c153d62cff4fbf5436b0c46a5e498a995449d7aa\` (pre-fix simulation, only \`Invoke Mode\` surfaces).

## Follow-up

A separate PR will replace the DOM-scrape visual validator (\`validation/playwright/validate-estimate.js\`) with a CSV-export oracle. The DOM oracle cannot detect this class of regression — proven by probes saved earlier; control vs broken estimates render byte-identical DOM. CSV \`Configuration summary\` is the discriminating signal.