### PR TITLE
feat: support nested group hierarchy in estimates

### DIFF
--- a/lib/estimate-builder.js
+++ b/lib/estimate-builder.js
@@ -60,6 +60,15 @@ function configSummary(config) {
     .join(', ');
 }
 
+// Normalize a group specifier into an ordered path of folder names.
+// Accepts undefined (ungrouped), a single name, a "/"-delimited string
+// (e.g. "Production/Presentation"), or an array of names.
+function toGroupPath(group) {
+  if (group == null) return [];
+  const parts = Array.isArray(group) ? group : String(group).split('/');
+  return parts.map(s => String(s).trim()).filter(Boolean);
+}
+
 class EstimateBuilder {
   constructor(name = 'My Estimate', partition = null) {
     this.id = crypto.randomUUID();
@@ -75,10 +84,19 @@ class EstimateBuilder {
       compositeKey = `${compositeKey}:${config.description.replace(/\s+/g, '')}`;
     }
     this.usedKeys.add(compositeKey);
-    const target = group
-      ? (this.groups[group] ??= { services: {} }).services
-      : this.services;
-    target[compositeKey] = config;
+    const path = toGroupPath(group);
+    if (path.length === 0) {
+      this.services[compositeKey] = config;
+      return;
+    }
+    // Walk/create the nested group tree. Each node holds its own direct
+    // services plus child groups, mirroring the calculator's recursive shape.
+    let node = this;
+    for (const name of path) {
+      node.groups ??= {};
+      node = (node.groups[name] ??= { services: {}, groups: {} });
+    }
+    node.services[compositeKey] = config;
   }
 
   _resolvePartition() {
@@ -164,17 +182,23 @@ class EstimateBuilder {
       return out;
     };
 
-    const groups = {};
-    for (const [name, data] of Object.entries(this.groups)) {
-      const safeName = sanitize(name);
-      groups[`${safeName}-${crypto.randomUUID()}`] = {
-        name: safeName,
-        services: await buildEntries(data.services),
-        groups: {},
-        //groupSubtotal: { monthly: 0 },
-        //totalCost: { monthly: 0, upfront: 0 },
-      };
-    }
+    // Recursively build the group tree so nested folders (e.g.
+    // Stamp -> Tier -> Resource) are preserved in the exported payload.
+    const buildGroups = async (groupMap) => {
+      const out = {};
+      for (const [name, data] of Object.entries(groupMap || {})) {
+        const safeName = sanitize(name);
+        out[`${safeName}-${crypto.randomUUID()}`] = {
+          name: safeName,
+          services: await buildEntries(data.services || {}),
+          groups: await buildGroups(data.groups),
+          //groupSubtotal: { monthly: 0 },
+          //totalCost: { monthly: 0, upfront: 0 },
+        };
+      }
+      return out;
+    };
+    const groups = await buildGroups(this.groups);
 
     const payload = {
       name: this.name,

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -229,11 +229,13 @@ IMPORTANT: Before calling this tool, you MUST confirm the desired AWS region wit
 
 Config keys are validated against the service definition. Invalid field IDs will be rejected with suggested corrections. Use get_service_fields first to discover valid field IDs for a service.
 
+The "group" field organizes services into folders. For nested folders, pass either a "/"-delimited string (e.g. "Production/Presentation") or an array of names (e.g. ["Production","Presentation"]). The calculator renders these as a folder hierarchy: Production > Presentation > service.
+
 For batch mode, pass a JSON array in "services":
-[{"service":"aWSLambda","instance":"Compute","group":"Prod","config":{...}},{"service":"amazonS3Standard","group":"Prod","config":{...}}]`,
+[{"service":"aWSLambda","instance":"Compute","group":"Prod","config":{...}},{"service":"amazonS3Standard","group":["Prod","Web"],"config":{...}}]`,
   {
     estimate_id: z.string().describe('Estimate ID from create_estimate'),
-    services: z.string().describe('JSON array of service entries. Each entry: {"service":"serviceKey","instance":"optional","group":"optional","config":{...with region, description, and field values}}. Example: [{"service":"aWSLambda","group":"Prod","config":{"region":"eu-west-1","description":"Compute","numberOfRequests":{"value":"19","unit":"millionPerMonth"}}}]'),
+    services: z.string().describe('JSON array of service entries. Each entry: {"service":"serviceKey","instance":"optional","group":"optional nested folder path as string \"A/B\" or array [\"A\",\"B\"]","config":{...with region, description, and field values}}. Example: [{"service":"aWSLambda","group":"Prod/Web","config":{"region":"eu-west-1","description":"Compute","numberOfRequests":{"value":"19","unit":"millionPerMonth"}}}]'),
   },
   async ({ estimate_id, services: servicesStr }) => {
     const estimate = estimates.get(estimate_id);

--- a/test/estimate-builder.test.js
+++ b/test/estimate-builder.test.js
@@ -84,6 +84,32 @@ describe('EstimateBuilder', () => {
       assert.equal(Object.keys(eb.groups.Prod.services).length, 1);
     });
   });
+
+  describe('nested groups', () => {
+    it('nests services under a "/"-delimited group path', () => {
+      const eb = new EstimateBuilder('test');
+      eb.addService('aWSLambda', { region: 'us-east-1' }, { group: 'Production/Presentation' });
+      assert.equal(Object.keys(eb.services).length, 0, 'ungrouped should be empty');
+      assert.ok(eb.groups.Production, 'parent group should exist');
+      assert.equal(Object.keys(eb.groups.Production.services).length, 0, 'parent has no direct services');
+      assert.ok(eb.groups.Production.groups.Presentation, 'child group should exist');
+      assert.equal(Object.keys(eb.groups.Production.groups.Presentation.services).length, 1);
+    });
+
+    it('accepts an array group path', () => {
+      const eb = new EstimateBuilder('test');
+      eb.addService('aWSLambda', { region: 'us-east-1' }, { group: ['Production', 'Presentation'] });
+      assert.ok(eb.groups.Production.groups.Presentation.services, 'should build the same tree as the string form');
+    });
+
+    it('merges siblings under a shared parent', () => {
+      const eb = new EstimateBuilder('test');
+      eb.addService('aWSLambda', { region: 'us-east-1', description: 'a' }, { group: 'Prod/Web' });
+      eb.addService('amazonS3Standard', { region: 'us-east-1', description: 'b' }, { group: 'Prod/Data' });
+      const prod = eb.groups.Prod;
+      assert.deepEqual(Object.keys(prod.groups).sort(), ['Data', 'Web'], 'both tiers share one Prod parent');
+    });
+  });
 });
 
 describe('toAWSPayload', () => {
@@ -159,6 +185,36 @@ describe('toAWSPayload', () => {
     assert.equal(groupServices.length, 2);
     const codes = groupServices.map(s => s.serviceCode).sort();
     assert.deepEqual(codes, ['aWSLambda', 'amazonS3Standard']);
+  });
+
+  it('builds payload with nested group hierarchy', async () => {
+    mockFetch([
+      ['manifest/en_US.json', FAKE_MANIFEST],
+      ['data/aWSLambda', FAKE_DEFINITION],
+      ['data/amazonS3Standard', FAKE_S3_DEFINITION],
+    ]);
+
+    const EB = require('../lib/estimate-builder');
+    const eb = new EB('Nested Estimate');
+    eb.addService('aWSLambda', { region: 'us-east-1', description: 'Web' }, { group: 'Production/Presentation' });
+    eb.addService('amazonS3Standard', { region: 'us-east-1', description: 'Blob' }, { group: 'Production/Presentation' });
+
+    const payload = await eb.toAWSPayload();
+
+    const topGroups = Object.values(payload.groups);
+    assert.equal(topGroups.length, 1, 'one top-level (Production) group');
+    const production = topGroups[0];
+    assert.equal(production.name, 'Production');
+    assert.equal(Object.keys(production.services).length, 0, 'Production has no direct services');
+
+    const childGroups = Object.values(production.groups);
+    assert.equal(childGroups.length, 1, 'one child (Presentation) group');
+    const presentation = childGroups[0];
+    assert.equal(presentation.name, 'Presentation');
+    assert.equal(Object.keys(presentation.services).length, 2, 'both services live in the leaf folder');
+    const codes = Object.values(presentation.services).map(s => s.serviceCode).sort();
+    assert.deepEqual(codes, ['aWSLambda', 'amazonS3Standard']);
+    assert.deepEqual(presentation.groups, {}, 'leaf group has empty groups');
   });
 
   it('falls back gracefully when definition fetch fails', async () => {


### PR DESCRIPTION
## Summary
- Closes #14.
- `add_service` now accepts a nested group path — a `"/"`-delimited string (`"Production/Presentation"`) or an array (`["Production","Presentation"]`) — and stores groups as a tree.
- `toAWSPayload` recurses into child groups instead of writing a hardcoded empty `groups: {}`, so estimates can express multi-level folder hierarchies (e.g. Environment → Tier → Resource).
- Backward-compatible: a bare `group` string still produces a single folder level; existing callers are unaffected.

## Changes
- `lib/estimate-builder.js`: new `toGroupPath()` helper; `addService` walks/creates a nested `{ services, groups }` tree; `toAWSPayload` builds groups recursively via `buildGroups()`.
- `mcp-server.js`: updated the `add_service` tool description to document the nested-path `group` argument.
- `test/estimate-builder.test.js`: added unit tests (string path, array path, sibling merge) and a `toAWSPayload` test asserting the nested payload shape.

## Test plan
- [x] `npm test` — 74 passing (70 prior + 4 new), no regressions.
- [x] `npm run build` succeeds.
- [x] Live round-trip against calculator.aws: exported an Environment → Tier → Resource estimate, imported it back, and confirmed the folder hierarchy is preserved.