### PR TITLE
feat: accept services_file path in add_service for large batches

### DIFF
--- a/mcp-server.js
+++ b/mcp-server.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
+const fs = require('fs');
 const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
 const { StdioServerTransport } = require('@modelcontextprotocol/sdk/server/stdio.js');
 const { z } = require('zod');
@@ -230,21 +231,39 @@ IMPORTANT: Before calling this tool, you MUST confirm the desired AWS region wit
 Config keys are validated against the service definition. Invalid field IDs will be rejected with suggested corrections. Use get_service_fields first to discover valid field IDs for a service.
 
 For batch mode, pass a JSON array in "services":
-[{"service":"aWSLambda","instance":"Compute","group":"Prod","config":{...}},{"service":"amazonS3Standard","group":"Prod","config":{...}}]`,
+[{"service":"aWSLambda","instance":"Compute","group":"Prod","config":{...}},{"service":"amazonS3Standard","group":"Prod","config":{...}}]
+
+For large batches, write that same JSON array to a file and pass its absolute path as "services_file" instead of "services". The server reads the file directly, avoiding the cost of streaming a large payload through the client. Supply exactly one of "services" or "services_file".`,
   {
     estimate_id: z.string().describe('Estimate ID from create_estimate'),
-    services: z.string().describe('JSON array of service entries. Each entry: {"service":"serviceKey","instance":"optional","group":"optional","config":{...with region, description, and field values}}. Example: [{"service":"aWSLambda","group":"Prod","config":{"region":"eu-west-1","description":"Compute","numberOfRequests":{"value":"19","unit":"millionPerMonth"}}}]'),
+    services: z.string().optional().describe('JSON array of service entries. Each entry: {"service":"serviceKey","instance":"optional","group":"optional","config":{...with region, description, and field values}}. Example: [{"service":"aWSLambda","group":"Prod","config":{"region":"eu-west-1","description":"Compute","numberOfRequests":{"value":"19","unit":"millionPerMonth"}}}]. Omit when using services_file.'),
+    services_file: z.string().optional().describe('Absolute path to a JSON file containing the same array that "services" accepts. Use this for large batches to avoid streaming the payload through the client. Supply either services or services_file, not both.'),
   },
-  async ({ estimate_id, services: servicesStr }) => {
+  async ({ estimate_id, services: servicesStr, services_file: servicesFile }) => {
     const estimate = estimates.get(estimate_id);
     if (!estimate) return { content: [{ type: 'text', text: `Estimate "${estimate_id}" not found.` }], isError: true };
 
+    if ((servicesStr == null) === (servicesFile == null)) {
+      return { content: [{ type: 'text', text: 'Supply exactly one of "services" or "services_file".' }], isError: true };
+    }
+
+    let rawJson;
+    if (servicesFile != null) {
+      try {
+        rawJson = fs.readFileSync(servicesFile, 'utf-8');
+      } catch (err) {
+        return { content: [{ type: 'text', text: `Could not read services_file "${servicesFile}": ${err.message}` }], isError: true };
+      }
+    } else {
+      rawJson = servicesStr;
+    }
+
     let entries;
     try {
-      entries = JSON.parse(servicesStr);
+      entries = JSON.parse(rawJson);
       if (!Array.isArray(entries)) entries = [entries];
     } catch {
-      return { content: [{ type: 'text', text: 'Invalid JSON in services parameter.' }], isError: true };
+      return { content: [{ type: 'text', text: `Invalid JSON in ${servicesFile != null ? 'services_file' : 'services parameter'}.` }], isError: true };
     }
 
     const results = [];


### PR DESCRIPTION
## Summary
- Adds an optional `services_file` parameter to `add_service`: an absolute path to a JSON file containing the same array the `services` parameter accepts. The server reads and parses the file directly.
- Makes `services` optional; exactly one of `services` / `services_file` must be supplied (errors if neither or both).
- All existing per-entry validation (`validateConfigKeys`, field-ID grounding) runs unchanged.

## Motivation
When an MCP client is an LLM agent, the batch `services` array must be re-serialized as generated tokens for each call. Large estimates (e.g. ~177 entries / ~90 KB) force the client to split into many small batches, which is slow and token-expensive. The bottleneck is the agent⇄tool data path, not `addService` itself. Passing a file path lets a producer hand off the payload on disk and import it in a single call.

Closes #16

## Test plan
- [x] `node --check mcp-server.js` clean
- [x] `npm test` — all unit tests pass
- [x] End-to-end: created an estimate, called `add_service` with `services_file` pointing at a 177-entry JSON array → 177 added, 0 errors in one call; `export_estimate` returned a working calculator.aws URL
- [x] Verified inline `services` path still works (back-compat)