### PR TITLE
fix(ec2): support Dedicated Host reserved instances and storage fields

### DIFF
--- a/lib/can-rehydrate.js
+++ b/lib/can-rehydrate.js
@@ -823,7 +823,7 @@ function checkUnknownFieldIds(svc, definition) {
   const validList = [...validIds];
   const failures = [];
   for (const key of ccKeys) {
-    if (validIds.has(key)) continue;
+    if (validIds.has(key) || key === 'vcpu' || key === 'physicalCores') continue;
     const suggestions = suggestNearbyIds(key, validList);
     const hint = suggestions.length
       ? ` Did you mean: ${suggestions.map(s => `"${s}"`).join(', ')}?`

--- a/lib/ec2.js
+++ b/lib/ec2.js
@@ -9,12 +9,12 @@ const traceEvents = require('./trace-events');
 const SHORTHAND_RE = /^(?:ri|reserved|convertible|instanceSavings|computeSavings|ondemand)(?:(\d)yr)?(?:(No|Partial|All)Upfront)?$/i;
 
 const MODEL_ALIASES = {
-  ri: 'reserved', reserved: 'reserved', convertible: 'convertible',
+  ri: 'reserved', reserved: 'reserved', standard: 'standard', convertible: 'convertible',
   instancesavings: 'instanceSavings', computesavings: 'computeSavings', ondemand: 'ondemand',
 };
 
 const SELECTED_OPTION = {
-  ondemand: 'on-demand', reserved: 'standard', convertible: 'convertible',
+  ondemand: 'on-demand', reserved: 'standard', standard: 'standard', convertible: 'convertible',
   instanceSavings: 'instance-savings', computeSavings: 'compute-savings', spot: 'spot',
 };
 
@@ -174,6 +174,14 @@ function transformConfig(config) {
     ...(config.iops && { iops: typeof config.iops === 'object' ? config.iops : { value: String(config.iops) } }),
     ...(config.iops2 && { iops2: typeof config.iops2 === 'object' ? config.iops2 : { value: String(config.iops2) } }),
     ...(config.storageAmountIo2 && { storageAmountIo2: typeof config.storageAmountIo2 === 'object' ? config.storageAmountIo2 : { value: String(config.storageAmountIo2), unit: 'gb|NA' } }),
+    ...(config.storageTypeDH && { storageTypeDH: typeof config.storageTypeDH === 'object' ? config.storageTypeDH : { value: config.storageTypeDH } }),
+    ...(config.storageAmountDH && { storageAmountDH: typeof config.storageAmountDH === 'object' ? config.storageAmountDH : { value: String(config.storageAmountDH), unit: 'gb|NA' } }),
+    ...(config.iopsDH && { iopsDH: typeof config.iopsDH === 'object' ? config.iopsDH : { value: String(config.iopsDH) } }),
+    ...(config.iops2DH && { iops2DH: typeof config.iops2DH === 'object' ? config.iops2DH : { value: String(config.iops2DH) } }),
+    ...(config.gp3IopsDH && { gp3IopsDH: typeof config.gp3IopsDH === 'object' ? config.gp3IopsDH : { value: String(config.gp3IopsDH) } }),
+    ...(config.gp3ThroughputDH && { gp3ThroughputDH: typeof config.gp3ThroughputDH === 'object' ? config.gp3ThroughputDH : { value: String(config.gp3ThroughputDH.value || config.gp3ThroughputDH), unit: 'mbps' } }),
+    ...(config.vcpu && { vcpu: typeof config.vcpu === 'object' ? config.vcpu : { value: String(config.vcpu) } }),
+    ...(config.physicalCores && { physicalCores: typeof config.physicalCores === 'object' ? config.physicalCores : { value: String(config.physicalCores) } }),
     // dataTransferForEC2 is injected by lib/handler-helpers.js#applyDefaultFields
     // when the catalog declares it under defaultFields. Pass through whatever
     // the agent (or default-field merge) supplied; if neither set it, the

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -279,7 +279,7 @@ async function validateConfigKeys(serviceKey, config, partition, catalog) {
     const fields = synthesizeAgentFields(svc.key, extractInputFields(def));
     const validIds = fields.map(f => f.id);
     const validSet = new Set(validIds);
-    const invalid = configKeys.filter(k => !validSet.has(k));
+    const invalid = configKeys.filter(k => !validSet.has(k) && k !== 'vcpu' && k !== 'physicalCores');
     if (invalid.length > 0) {
       const lines = invalid.map(k => {
         const suggestions = suggestMatch(k, validIds);


### PR DESCRIPTION
Improve compatibility with AWS Pricing Calculator exports for Dedicated Host (host tenancy) configurations.

Changes:
- Add `standard` Reserved Instance model mapping
  - Recognize `standard` in `MODEL_ALIASES` and `SELECTED_OPTION`.
  - AWS Pricing Calculator uses `standard` instead of `reserved` for Dedicated Host Reservations, and without this mapping the pricing model falls back to On-Demand.

- Support Dedicated Host EBS storage fields
  - Map Dedicated Host-specific storage field IDs in `lib/ec2.js`, including: - `storageAmountDH` - `storageTypeDH` - `gp3IopsDH` - `gp3ThroughputDH`
  - Ensures storage capacity, IOPS, and throughput are correctly preserved when generating estimates for Dedicated Hosts.

- Allow Dedicated Host hardware metadata during validation
  - Exempt `vcpu` and `physicalCores` from invalid field validation in `lib/validation.js`.
  - These fields are automatically included by the AWS Pricing Calculator when saving Dedicated Host estimates, despite not being part of the public input schema.

Together these changes enable accurate parsing, validation, and estimate generation for Dedicated Host configurations without incorrectly downgrading reservations to On-Demand or rejecting valid calculator exports.

*Issue #, if available:*

*Description of changes:*

### Description
### Summary of Changes
This PR adds support for Dedicated Host mapping, storage parsing, and validation bypasses within the MCP server's EC2 and validation modules:

1. **Standard Host Reservation Model Mapping** (`lib/ec2.js`):
   Adds `"standard"` to the `MODEL_ALIASES` and `SELECTED_OPTION` maps. Standard bare-metal Host Reservations (tenancy: `"host"`) use `model: "standard"` rather than `"reserved"`. Without this, standard reservation models would not be mapped correctly.
   
2. **Dedicated Host EBS Fields** (`lib/ec2.js`):
   Maps Dedicated Host specific EBS storage suffix fields (`storageTypeDH`, `storageAmountDH`, `gp3IopsDH`, `gp3ThroughputDH`) from the config payload. These `DH`-suffixed keys are required by the calculator engine under host tenancy to capture and compute storage costs.

3. **Validation Bypasses** (`lib/validation.js` & `lib/can-rehydrate.js`):
   Bypasses unknown-field validation errors for `vcpu` and `physicalCores` tags. These tags are automatically included in saved estimate payloads under host tenancy, but since they are not direct input components, they were previously flagging validation errors and blocking estimate rehydration.

---

### ⚠️ Note for Maintainers: Associated AWS Pricing Calculator Website UI Bug
While implementing and testing these changes, we identified a calculation engine bug on the main AWS Pricing Calculator website (`calculator.aws`) that we wanted to report to the product team:

* **The Issue**: Any saved estimate containing a physical Dedicated Host configured with standard **Host Reservations** (e.g. 3-Year No Upfront Reserved) calculates as **$0.00** in the browser UI (both in `eu-central-1` and `us-east-1`), even though the correct pricing rates exist in the CDN primary selector aggregations (e.g. `dedicatedhost-calc` maps).
* **Impact**: Users loading shared estimate links containing Reserved Dedicated Hosts see `$0.00` monthly host compute costs. 
* **Workaround**: We had to map host tenancy pricing strategies to On-Demand for our clients to bypass this UI rendering issue.

We would appreciate it if you could route this calculation engine bug to the internal AWS Pricing Calculator product/UI team for resolution!




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
