### PR TITLE
feat: increase JSON payload size limit to 10MB on HTTP transport

### DIFF
--- a/mcp-server.js
+++ b/mcp-server.js
@@ -382,7 +382,7 @@ async function main() {
     // nosemgrep: lazy-load-module
     const express = require('express');
     const app = express();
-    app.use(express.json());
+    app.use(express.json({ limit: '10mb' }));
     // No CSRF middleware: this endpoint speaks JSON-RPC, not HTML forms.
     // It uses no cookies and relies on transport-level auth (bearer token /
     // SigV4 / network policy) configured by the deployment, not browser

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,6 +110,7 @@
       "integrity": "sha512-kh+OsHfG8DvCA5hmflfIcj7c05wK6PSo2tZCLU3quVZ2GCcBAj0N66I5d+iIfoLmULydZqc4ChYabh3c6wdJPA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1633,6 +1634,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1891,6 +1893,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2541,6 +2544,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "sample-aws-pricing-calculator-mcp",
-      "version": "1.2.1",
+      "version": "1.2.7",
       "license": "MIT-0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -110,7 +110,6 @@
       "integrity": "sha512-kh+OsHfG8DvCA5hmflfIcj7c05wK6PSo2tZCLU3quVZ2GCcBAj0N66I5d+iIfoLmULydZqc4ChYabh3c6wdJPA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1634,7 +1633,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1893,7 +1891,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2544,7 +2541,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sample-aws-pricing-calculator-mcp",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "bin": "dist/mcp-server.js",
   "files": [
     "dist/mcp-server.js",


### PR DESCRIPTION
- Updates the Express JSON body-parser limit to 10MB (previously defaulting to 100KB) in mcp-server.js.
- This resolves an issue where the `build_estimate` tool fails with a 413 Payload Too Large error when parsing large service arrays.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
